### PR TITLE
Work on the circuit breaker behavior checkpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ buildNumber.properties
 
 ## File-based project format:
 *.iws
+*.iml
+*.ipr
 
 ## Plugin-specific files:
 

--- a/implementation/pom.xml
+++ b/implementation/pom.xml
@@ -55,7 +55,14 @@
       <groupId>com.netflix.hystrix</groupId>
       <artifactId>hystrix-core</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -71,6 +78,11 @@
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-core-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <version>3.3.1.Final</version>
     </dependency>
 
     <dependency>

--- a/implementation/src/main/java/org/wildfly/swarm/microprofile/fault/tolerance/hystrix/DefaultCommand.java
+++ b/implementation/src/main/java/org/wildfly/swarm/microprofile/fault/tolerance/hystrix/DefaultCommand.java
@@ -20,6 +20,8 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
+import com.netflix.hystrix.HystrixCircuitBreaker;
+import org.wildfly.swarm.microprofile.fault.tolerance.hystrix.config.CircuitBreakerConfig;
 import org.wildfly.swarm.microprofile.fault.tolerance.hystrix.config.RetryContext;
 
 
@@ -38,7 +40,12 @@ public class DefaultCommand extends com.netflix.hystrix.HystrixCommand<Object> {
         this.toRun = toRun;
         this.fallback = fallback;
         this.retryContext = retryContext;
-
+    }
+    protected DefaultCommand(Setter setter, Supplier<Object> toRun, Supplier<Object> fallback, RetryContext retryContext, HystrixCircuitBreaker circuitBreaker) {
+        super(setter, circuitBreaker);
+        this.toRun = toRun;
+        this.fallback = fallback;
+        this.retryContext = retryContext;
     }
 
     @Override

--- a/implementation/src/main/java/org/wildfly/swarm/microprofile/fault/tolerance/hystrix/HystrixCommandInterceptor.java
+++ b/implementation/src/main/java/org/wildfly/swarm/microprofile/fault/tolerance/hystrix/HystrixCommandInterceptor.java
@@ -32,6 +32,7 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
+import com.netflix.hystrix.HystrixCircuitBreaker;
 import com.netflix.hystrix.HystrixCommand.Setter;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandKey;
@@ -46,11 +47,13 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.FallbackHandler;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.wildfly.swarm.microprofile.fault.tolerance.hystrix.config.BulkheadConfig;
 import org.wildfly.swarm.microprofile.fault.tolerance.hystrix.config.CircuitBreakerConfig;
 import org.wildfly.swarm.microprofile.fault.tolerance.hystrix.config.FallbackConfig;
+import org.wildfly.swarm.microprofile.fault.tolerance.hystrix.config.GenericConfig;
 import org.wildfly.swarm.microprofile.fault.tolerance.hystrix.config.RetryContext;
 import org.wildfly.swarm.microprofile.fault.tolerance.hystrix.config.TimeoutConfig;
 
@@ -89,28 +92,53 @@ public class HystrixCommandInterceptor {
 
 
         Asynchronous async = getAnnotation(method, Asynchronous.class);
-
+        SynchronousCircuitBreaker syncCircuitBreaker = null;
         while (shouldRunCommand) {
             shouldRunCommand = false;
-            DefaultCommand command = new DefaultCommand(metadata.setter, ctx::proceed, fallback, metadata.retryContext);
+            DefaultCommand command;
+            if (metadata.config instanceof CircuitBreakerConfig) {
+                HystrixCommandKey key = HystrixCommandKey.Factory.asKey(method.getDeclaringClass().getName() + method.toString());
+                syncCircuitBreaker = SynchronousCircuitBreaker.getCircuitBreaker(key, (CircuitBreakerConfig) metadata.config);
+                command = new DefaultCommand(metadata.setter, ctx::proceed, fallback, metadata.retryContext, syncCircuitBreaker);
+            } else {
+                command = new DefaultCommand(metadata.setter, ctx::proceed, fallback, metadata.retryContext);
+            }
 
-
+            if (syncCircuitBreaker != null && syncCircuitBreaker.allowRequest() == false) {
+                throw new CircuitBreakerOpenException(method.getName());
+            }
             try {
                 if (async != null) {
                     res = command.queue();
                 } else {
                     res = command.execute();
                 }
+                if (syncCircuitBreaker != null) {
+                    syncCircuitBreaker.incSuccessCount();
+                }
             } catch (HystrixRuntimeException e) {
-                if (e.getFailureType().equals(HystrixRuntimeException.FailureType.TIMEOUT)) {
-                    if (metadata.retryContext != null && metadata.retryContext.getMaxExecNumber() > 0) {
-                        //retry.incMaxNumberExec();
-                        shouldRunCommand = true;
-                        continue;
+                if (syncCircuitBreaker != null) {
+                    syncCircuitBreaker.incFailureCount();
+                }
+                HystrixRuntimeException.FailureType failureType = e.getFailureType();
+                switch (failureType) {
+                    case TIMEOUT: {
+                        if (metadata.retryContext != null && metadata.retryContext.getMaxExecNumber() > 0) {
+                            //retry.incMaxNumberExec();
+                            shouldRunCommand = true;
+                            continue;
+                        }
+                        throw new TimeoutException(e);
                     }
-                    throw new TimeoutException(e);
-                } else {
-                    throw e;
+                    case SHORTCIRCUIT:
+                        throw new CircuitBreakerOpenException(method.getName());
+                    case REJECTED_THREAD_EXECUTION:
+                    case REJECTED_SEMAPHORE_EXECUTION:
+                    case REJECTED_SEMAPHORE_FALLBACK:
+                    case BAD_REQUEST_EXCEPTION:
+                    case COMMAND_EXCEPTION:
+                    default:
+                        throw e;
                 }
             }
         }
@@ -136,7 +164,7 @@ public class HystrixCommandInterceptor {
         return null;
     }
 
-    private Setter initSetter(Method method) {
+    private Setter initSetter(Method method, GenericConfig configValue[]) {
         HystrixCommandProperties.Setter propertiesSetter = HystrixCommandProperties.Setter();
 
         HystrixThreadPoolProperties.Setter threadPoolSetter = HystrixThreadPoolProperties.Setter();
@@ -150,6 +178,7 @@ public class HystrixCommandInterceptor {
             if (nonFallBackEnable && timeout != null) {
                 // TODO: In theory a user might specify a long value
                 TimeoutConfig config = new TimeoutConfig(timeout, method);
+                configValue[0] = config;
                 propertiesSetter.withExecutionTimeoutInMilliseconds((int) Duration.of(config.get(TimeoutConfig.VALUE), config.get(TimeoutConfig.UNIT)).toMillis());
             } else {
                 propertiesSetter.withExecutionTimeoutEnabled(false);
@@ -157,19 +186,21 @@ public class HystrixCommandInterceptor {
 
             if (nonFallBackEnable && circuitBreaker != null) {
 
-                CircuitBreakerConfig conf = new CircuitBreakerConfig(circuitBreaker, method);
+                CircuitBreakerConfig config = new CircuitBreakerConfig(circuitBreaker, method);
+                configValue[0] = config;
                 propertiesSetter.withCircuitBreakerEnabled(true)
-                        .withCircuitBreakerRequestVolumeThreshold(conf.get(CircuitBreakerConfig.REQUEST_VOLUME_THRESHOLD))
-                        .withCircuitBreakerErrorThresholdPercentage(new Double((Double) conf.get(CircuitBreakerConfig.FAILURE_RATIO) * 100).intValue())
-                        .withCircuitBreakerSleepWindowInMilliseconds((int) Duration.of(conf.get(CircuitBreakerConfig.DELAY), conf.get(CircuitBreakerConfig.DELAY_UNIT)).toMillis());
+                        .withCircuitBreakerRequestVolumeThreshold(config.get(CircuitBreakerConfig.REQUEST_VOLUME_THRESHOLD))
+                        .withCircuitBreakerErrorThresholdPercentage(new Double((Double) config.get(CircuitBreakerConfig.FAILURE_RATIO) * 100).intValue())
+                        .withCircuitBreakerSleepWindowInMilliseconds((int) Duration.of(config.get(CircuitBreakerConfig.DELAY), config.get(CircuitBreakerConfig.DELAY_UNIT)).toMillis());
             } else {
                 propertiesSetter.withCircuitBreakerEnabled(false);
             }
 
 
             if (nonFallBackEnable && bulkhead != null) {
-                BulkheadConfig conf = new BulkheadConfig(bulkhead, method);
-                propertiesSetter.withExecutionIsolationSemaphoreMaxConcurrentRequests(conf.get(BulkheadConfig.VALUE))
+                BulkheadConfig config = new BulkheadConfig(bulkhead, method);
+                configValue[0] = config;
+                propertiesSetter.withExecutionIsolationSemaphoreMaxConcurrentRequests(config.get(BulkheadConfig.VALUE))
                         .withExecutionIsolationThreadInterruptOnFutureCancel(true);
 
                 //threadPoolSetter.withCoreSize(conf.get(BulkheadConfig.VALUE));
@@ -200,7 +231,9 @@ public class HystrixCommandInterceptor {
     private class CommandMetadata {
 
         public CommandMetadata(Method method) {
-            setter = initSetter(method);
+            GenericConfig configValue[] = new GenericConfig[1];
+            setter = initSetter(method, configValue);
+            this.config = configValue[0];
 
             Fallback fallback = getAnnotation(method, Fallback.class);
 
@@ -243,6 +276,10 @@ public class HystrixCommandInterceptor {
             return unmanaged != null;
         }
 
+        GenericConfig getConfig() {
+            return config;
+        }
+
         private final Setter setter;
 
         private final Unmanaged<FallbackHandler<?>> unmanaged;
@@ -253,6 +290,7 @@ public class HystrixCommandInterceptor {
 
         private Method fallbackMethod = null;
 
+        private GenericConfig config;
     }
 
 }

--- a/implementation/src/main/java/org/wildfly/swarm/microprofile/fault/tolerance/hystrix/SynchronousCircuitBreaker.java
+++ b/implementation/src/main/java/org/wildfly/swarm/microprofile/fault/tolerance/hystrix/SynchronousCircuitBreaker.java
@@ -1,0 +1,187 @@
+package org.wildfly.swarm.microprofile.fault.tolerance.hystrix;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import com.netflix.hystrix.HystrixCircuitBreaker;
+import com.netflix.hystrix.HystrixCommandKey;
+import org.jboss.logging.Logger;
+import org.wildfly.swarm.microprofile.fault.tolerance.hystrix.config.CircuitBreakerConfig;
+
+/**
+ * This is an implementation of the HystrixCircuitBreaker that is expected to be used synchronously by the
+ * HystrixCommand implementation to track the state of the circuit. This is needed for the current TCK
+ * tests as 
+ */
+public class SynchronousCircuitBreaker implements HystrixCircuitBreaker {
+    private static Logger log = Logger.getLogger(SynchronousCircuitBreaker.class);
+    enum Status {
+        CLOSED, OPEN, HALF_OPEN;
+    }
+
+    static SynchronousCircuitBreaker getCircuitBreaker(HystrixCommandKey key, final CircuitBreakerConfig config) {
+        Function<HystrixCommandKey, SynchronousCircuitBreaker> newFunc = (key1) -> new SynchronousCircuitBreaker(config);
+        SynchronousCircuitBreaker circuitBreaker = circuitBreakerMap.computeIfAbsent(key, newFunc);
+        return circuitBreaker;
+    }
+
+    SynchronousCircuitBreaker(CircuitBreakerConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public void markSuccess() {
+        // If we were half open, close the circuit and reset
+        if (status.compareAndSet(Status.HALF_OPEN, Status.CLOSED)) {
+            log.infof("markSuccess, reset");
+            reset();
+        }
+    }
+
+    /**
+     * Update the circuit state with a failed invocation
+     */
+    @Override
+    public void markNonSuccess() {
+        if (status.compareAndSet(Status.HALF_OPEN, Status.OPEN)) {
+            // The next error during half open state leads to a fully open circuit
+            circuitOpenedTime.set(System.currentTimeMillis());
+            log.infof("markNonSuccess, HALF_OPEN to OPEN, circuitOpenedTime=%d", circuitOpenedTime.get());
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        log.infof("isOpen, %s, failures=%d, total=%d", status.get(), failureCount, getTotalCount());
+
+        return status.get() == Status.OPEN;
+    }
+
+    /**
+     *
+     * @return true if the circuit is closed or open and within the delay window
+     */
+    @Override
+    public boolean allowRequest() {
+        boolean allowRequest = false;
+        if (status.get() == Status.CLOSED) {
+            allowRequest = true;
+        } else {
+            if (status.get().equals(Status.HALF_OPEN)) {
+                allowRequest = false;
+            } else {
+                allowRequest = isAfterDelayWindow();
+            }
+        }
+        return allowRequest;
+    }
+
+    @Override
+    public boolean attemptExecution() {
+        boolean attemptExecution = false;
+        if (circuitOpenedTime.get() == -1) {
+            // Circuit is closed
+            attemptExecution = true;
+        } else {
+            if (isAfterDelayWindow()) {
+                // Only the first invocation puts the circuit into half open
+                if (status.compareAndSet(Status.OPEN, Status.HALF_OPEN)) {
+                    attemptExecution = true;
+                } else {
+                    attemptExecution = false;
+                }
+            } else {
+                // A successful invocation is required
+                attemptExecution = false;
+            }
+        }
+        log.infof("attemptExecution(%s), status=%s", attemptExecution, status.get());
+
+        return attemptExecution;
+    }
+
+    int incSuccessCount() {
+        int count = successCount.incrementAndGet();
+        log.infof("incSuccessCount(%d), status=%s", count, status.get());
+        return count;
+    }
+    int incFailureCount() {
+        int count = failureCount.incrementAndGet();
+        log.infof("incFailureCount(%d), status=%s", count, status.get());
+        updateCircuitStatus();
+        return count;
+    }
+
+    private void updateCircuitStatus() {
+        if(status.get() == Status.CLOSED) {
+            int count = getTotalCount();
+            int requestVolumeThreshold = config.get(CircuitBreakerConfig.REQUEST_VOLUME_THRESHOLD, Integer.class);
+            log.infof("markNonSuccess, CLOSED(%d/%d)", count, requestVolumeThreshold);
+            if (count >= requestVolumeThreshold) {
+                // There are enough requests to calculate the error rate
+                double errorRate = getErrorRate();
+                double failureRatio = getfailureRatio();
+                log.infof("markNonSuccess, CLOSED, errorRate=%.2f, failureRatio=%.2f", errorRate, failureRatio);
+                if (errorRate >= failureRatio) {
+                    // The error rate is too high, transition from closed to open
+                    if (status.compareAndSet(Status.CLOSED, Status.OPEN)) {
+                        circuitOpenedTime.set(System.currentTimeMillis());
+                        log.infof("markNonSuccess, CLOSED to OPEN, circuitOpenedTime=%d", circuitOpenedTime.get());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Is the circuit after the window of opening and the @CircuitBreaker(delay) value
+     * @return true if the circuit is open and within the configured delay
+     */
+    private boolean isAfterDelayWindow() {
+        final long circuitOpenTime = circuitOpenedTime.get();
+        final long currentTime = System.currentTimeMillis();
+        final long delayWindowMS = config.get(CircuitBreakerConfig.DELAY, Long.class);
+        return currentTime > (circuitOpenTime + delayWindowMS);
+    }
+
+    /**
+     * Not sure how to apply this yet.
+     * @return
+     */
+    private boolean isAboveSuccessThreshold() {
+        int threshold = config.get(CircuitBreakerConfig.SUCCESS_THRESHOLD, Integer.class);
+        return successCount.get() >= threshold;
+    }
+
+    private double getErrorRate() {
+        double errorRate = failureCount.doubleValue();
+        double totalCount = errorRate + successCount.doubleValue();
+        errorRate /= totalCount;
+        return errorRate;
+    }
+    private double getfailureRatio() {
+        double failureRatio = config.get(CircuitBreakerConfig.FAILURE_RATIO, Double.class);
+        return failureRatio;
+    }
+    private int getTotalCount() {
+        return successCount.get() + failureCount.get();
+    }
+    private void reset() {
+        circuitOpenedTime.set(-1);
+        successCount.set(-1);
+        failureCount.set(0);
+    }
+
+    // The current circuit status
+    private final AtomicReference<Status> status = new AtomicReference<Status>(Status.CLOSED);
+    // The last time the circuit was opened, -1 for closed
+    private final AtomicLong circuitOpenedTime = new AtomicLong(-1);
+    // The circuit configuration
+    private final CircuitBreakerConfig config;
+    private AtomicInteger successCount = new AtomicInteger(0);
+    private AtomicInteger failureCount = new AtomicInteger(0);
+    private static ConcurrentHashMap<HystrixCommandKey, SynchronousCircuitBreaker> circuitBreakerMap = new ConcurrentHashMap<>();
+}

--- a/implementation/src/main/java/org/wildfly/swarm/microprofile/fault/tolerance/hystrix/config/CircuitBreakerConfig.java
+++ b/implementation/src/main/java/org/wildfly/swarm/microprofile/fault/tolerance/hystrix/config/CircuitBreakerConfig.java
@@ -29,6 +29,8 @@ public class CircuitBreakerConfig extends GenericConfig<CircuitBreaker> {
 
     public static final String SUCCESS_THRESHOLD = "successThreshold";
 
+    public static final String SYNCHRONOUS_STATE_VALIDATION = "synchronousStateValidation";
+
     public CircuitBreakerConfig(CircuitBreaker cb, Method method) {
         super(cb, method);
     }
@@ -70,6 +72,7 @@ public class CircuitBreakerConfig extends GenericConfig<CircuitBreaker> {
         put(FAILURE_RATIO, Double.class);
         put(REQUEST_VOLUME_THRESHOLD, Integer.class);
         put(SUCCESS_THRESHOLD, Integer.class);
+        put(SYNCHRONOUS_STATE_VALIDATION, Boolean.class);
     }});
 
 

--- a/implementation/src/test/java/org/wildfly/swarm/microprofile/fault/tolerance/hystrix/MyMicroservice.java
+++ b/implementation/src/test/java/org/wildfly/swarm/microprofile/fault/tolerance/hystrix/MyMicroservice.java
@@ -19,6 +19,7 @@ package org.wildfly.swarm.microprofile.fault.tolerance.hystrix;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
@@ -27,6 +28,7 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
  * @author Antoine Sabot-Durand
  */
 @ApplicationScoped
+@CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 4, failureRatio=0.75, delay = 50000)
 public class MyMicroservice {
 
     @Timeout(500)
@@ -82,5 +84,73 @@ public class MyMicroservice {
         return HELLO;
     }
 
+    @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 4, failureRatio=0.75, delay = 50000)
+    public String sayHelloBreaker() {
+        sayHelloBreakerCount ++;
+        if(sayHelloBreakerCount < 5) {
+            throw new RuntimeException("Connection failed");
+        }
+        return "sayHelloBreaker#"+sayHelloBreakerCount;
+    }
+
+    public String sayHelloBreakerClassLevel() {
+        sayHelloBreakerCount3 ++;
+        if(sayHelloBreakerCount3 < 5) {
+            throw new RuntimeException("Connection failed");
+        }
+        return "sayHelloBreakerClassLevel#"+sayHelloBreakerCount3;
+    }
+    public int getSayHelloBreakerCount3() {
+        return sayHelloBreakerCount3;
+    }
+
+    public int getSayHelloBreakerCount() {
+        return sayHelloBreakerCount;
+    }
+
+    @CircuitBreaker(successThreshold = 1, requestVolumeThreshold = 4, failureRatio=0.75, delay = 1000)
+    public String sayHelloBreaker2() {
+        sayHelloBreakerCount2 ++;
+        // Only one execution succeeds
+        if(sayHelloBreakerCount2 != 5) {
+            throw new RuntimeException("Connection failed");
+        }
+        return "sayHelloBreaker#"+sayHelloBreakerCount2;
+    }
+    public int getSayHelloBreakerCount2() {
+        return sayHelloBreakerCount2;
+    }
+
+    @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 2, failureRatio = 1, delay = 50000)
+    public String sayHelloBreakerOverride() {
+        sayHelloBreakerCount4 ++;
+        // Only one execution succeeds
+        if(sayHelloBreakerCount4 != 5) {
+            throw new RuntimeException("Connection failed");
+        }
+        return "sayHelloBreaker#"+sayHelloBreakerCount2;
+    }
+    public int getSayHelloBreakerCount4() {
+        return sayHelloBreakerCount4;
+    }
+
+    @CircuitBreaker(successThreshold = 3, requestVolumeThreshold = 4, failureRatio=0.75, delay = 1000)
+    public String sayHelloBreakerHighThreshold() {
+        sayHelloBreakerCount5 ++;
+        // Only one execution succeeds
+        if(sayHelloBreakerCount5 < 5 || sayHelloBreakerCount5 > 6) {
+            throw new RuntimeException("Connection failed");
+        }
+        return "sayHelloBreaker#"+sayHelloBreakerCount2;
+    }
+    public int getSayHelloBreakerCount5() {
+        return sayHelloBreakerCount5;
+    }
+
+    private int sayHelloBreakerCount;
+    private int sayHelloBreakerCount2;
+    private int sayHelloBreakerCount3;
+    private int sayHelloBreakerCount4;
+    private int sayHelloBreakerCount5;
     static final String HELLO = "Hello";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <version.microprofile-fault-tolerance-api>1.0</version.microprofile-fault-tolerance-api>
     <version.cdi-api>1.2</version.cdi-api>
     <version.javax.annotation-api>1.2</version.javax.annotation-api>
-    <version.hystrix-core>1.5.12</version.hystrix-core>
+    <version.hystrix-core>1.6.0-SNAPSHOT</version.hystrix-core>
     <version.weld-junit4>1.1.0.Final</version.weld-junit4>
     <version.slf4j>1.7.10</version.slf4j>
     <version.arquillian-universe>1.1.13.7</version.arquillian-universe>
@@ -97,6 +97,17 @@
         <artifactId>hystrix-core</artifactId>
         <version>${version.hystrix-core}</version>
       </dependency>
+      <dependency>
+        <groupId>io.reactivex</groupId>
+        <artifactId>rxjava</artifactId>
+        <version>1.2.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hdrhistogram</groupId>
+        <artifactId>HdrHistogram</artifactId>
+        <version>2.1.9</version>
+      </dependency>
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -23,6 +23,14 @@
       <groupId>com.netflix.hystrix</groupId>
       <artifactId>hystrix-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>

--- a/tck-runner/src/test/resources/tck-suite.xml
+++ b/tck-runner/src/test/resources/tck-suite.xml
@@ -36,14 +36,15 @@
 
 
      <class name="org.eclipse.microprofile.fault.tolerance.tck.FallbackTest">
-       <!--issue with timeout and fallback-->
+       <!--issue with timeout and fallback
        <methods>
          <exclude name="testFallbackTimeout"/>
        </methods>
+       -->
      </class>
 
       <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerTest">
-        <!--5 tests out of 7 don't pass-->
+        <!--5 tests out of 7 don't pass
         <methods>
           <exclude name="testCircuitClosedThenOpen" />
           <exclude name="testCircuitDefaultSuccessThreshold"/>
@@ -52,14 +53,17 @@
           <exclude name="testClassLevelCircuitOverride"/>
           <exclude name="testClassLevelCircuitOverrideNoDelay"/>
         </methods>
+        -->
       </class>
 
       <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerRetryTest">
+        <!--
         <methods>
           <exclude name="testCircuitOpenWithMoreRetries"/>
           <exclude name="testCircuitOpenWithMultiTimeouts"/>
           <exclude name="testClassLevelCircuitOpenWithMoreRetries"/>
         </methods>
+        -->
       </class>
 
       <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest"/>


### PR DESCRIPTION
This is an initial checkpoint. It brings the current tck results to:
Failed tests: 
  CircuitBreakerRetryTest>Arquillian.run:164->testCircuitOpenWithMoreRetries:86 serviceA should retry or throw a CircuitBreakerOpenException in testCircuitOpenWithMoreRetries on iteration 8
  CircuitBreakerRetryTest>Arquillian.run:164->testCircuitOpenWithMultiTimeouts:237 serviceC should retry or throw a CircuitBreakerOpenException in testCircuitOpenWithMoreRetries on iteration 8
  CircuitBreakerRetryTest>Arquillian.run:164->testClassLevelCircuitOpenWithMoreRetries:161 serviceA should retry or throw a CircuitBreakerOpenException in testClassLevelCircuitOpenWithMoreRetries on iteration 8
  CircuitBreakerTest>Arquillian.run:164->testCircuitHighSuccessThreshold:301 The number of serviceA executions should be 7 expected [7] but found [8]

Tests run: 85, Failures: 4, Errors: 0, Skipped: 0

Signed-off-by: Scott Stark <starksm64@gmail.com>