### PR TITLE
SWARM-1664 MP Fault tolerance build should trigger TCK by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: java
-sudo: false
-jdk:
-  - oraclejdk8
-  - openjdk8
-script: "mvn verify -Ptck"
-cache:
-  directories:
-  - $HOME/.m2/repository

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -65,6 +65,11 @@
   <profiles>
     <profile>
       <id>tck</id>
+      <activation>
+        <property>
+          <name>!skipTck</name>
+        </property>
+      </activation>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
TCK tests are launch by default. They can be skipped by -DskipTck in build

Signed-off-by: Antoine Sabot-Durand <antoine@sabot-durand.net>